### PR TITLE
Remover total de doações do título no v1

### DIFF
--- a/index.html
+++ b/index.html
@@ -212,7 +212,7 @@
               </div>
               
               <div class="progress">
-                <span class="skill">Hospital Várzea do Carmo - COVID Capital 3<i class="val">50 unidades</i></span>
+                <span class="skill">H. Várzea do Carmo - COVID Capital 3<i class="val">50 unidades</i></span>
                 <div class="progress-bar-wrap">
                   <div class="progress-bar" role="progressbar" aria-valuenow="24" aria-valuemin="0" aria-valuemax="100"></div>
                 </div>

--- a/index.html
+++ b/index.html
@@ -146,6 +146,7 @@
 
       <section id="skills" class="skills">
         <div class="container">
+          <h3>Doações</h3>
           <div class="row skills-content">
             <div class="col-lg-6">
               <div class="progress">

--- a/index.html
+++ b/index.html
@@ -146,12 +146,8 @@
 
       <section id="skills" class="skills">
         <div class="container">
-          <h3>Doações - 1.352 unidades</h3>
-  
           <div class="row skills-content">
-  
             <div class="col-lg-6">
-  
               <div class="progress">
                 <span class="skill">GRAAC<i class="val">150 unidades</i></span>
                 <div class="progress-bar-wrap">


### PR DESCRIPTION
## O que foi feito? :thinking:
Essa alteração é referente a issue #118 

## Como foi feito? :page_with_curl:
  - Removido total de doações do título
  - Ajustado título de `HOSPITAL VÁRZEA DO CARMO - COVID CAPITAL 3` que estava quebrando nas versões mobile